### PR TITLE
changed user root to none for openSUSE images

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -273,7 +273,7 @@
 
 - name: openSUSE Leap 42.3 (20180629)
   format: qcow2
-  login: root
+  login: none
   min_disk: 8
   min_ram: 512
   status: active
@@ -289,7 +289,7 @@
 
 - name: openSUSE Leap 15.0 (20180628)
   format: qcow2
-  login: root
+  login: none
   min_disk: 8
   min_ram: 512
   status: active
@@ -305,7 +305,7 @@
 
 - name: openSUSE Tumbleweed (20180630)
   format: qcow2
-  login: root
+  login: none
   min_disk: 8
   min_ram: 512
   status: active


### PR DESCRIPTION
changed user root to none for openSUSE images, as they do not have a root password set

See e.g. [here for Leap 15.0](https://build.opensuse.org/package/view_file/Cloud:Images:Leap_15.0/openSUSE-Leap-15.0-OpenStack-Guest/config.sh?expand=1) or [here for 42.3](https://build.opensuse.org/package/view_file/Cloud:Images:Leap_42.3/openSUSE-Leap-42.3-OpenStack-Guest/config.sh?expand=1)

```
# Remove the password for root
# Note the string matches the password set in the config file
sed -i 's/$1$wYJUgpM5$RXMMeASDc035eX.NbYWFl0/*/' /etc/shadow
```