### PR TITLE
Remove RancherOS v1.4.1, due CVE-2019-5736

### DIFF
--- a/etc/images.yml
+++ b/etc/images.yml
@@ -132,8 +132,6 @@ images:
       hw_watchdog_action: reset
     tags: []
     versions:
-      - version: '1.4.3'
-        url: https://github.com/rancher/os/releases/download/v1.4.3/rancheros-openstack.img
       - version: '1.5.1'
         url: https://github.com/rancher/os/releases/download/v1.5.1/rancheros-openstack.img
 


### PR DESCRIPTION
see https://github.com/rancher/os/releases/tag/v1.5.1

Signed-off-by: Thorsten Schifferdecker <schifferdecker@b1-systems.de>